### PR TITLE
fix shared-file rollback when updaters overlap

### DIFF
--- a/src/data-manager.test.ts
+++ b/src/data-manager.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DataManager } from "./data-manager.js";
+import { mergeData } from "./utils.js";
+import type { DataUpdater } from "./types.js";
+
+const sharedFile = "./data/shared.json";
+
+describe("DataManager", () => {
+  let originalCwd: string;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = await mkdtemp(join(tmpdir(), "lender-metadata-test-"));
+    await mkdir(join(tempDir, "data"), { recursive: true });
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps updates from earlier updaters writing same file", async () => {
+    await writeFile(
+      sharedFile,
+      JSON.stringify({ a: "old-a", b: "old-b" }, null, 2) + "\n",
+      "utf8"
+    );
+
+    const updaterA: DataUpdater = {
+      name: "Updater A",
+      defaults: {},
+      async fetchData() {
+        return { [sharedFile]: { a: "new-a" } };
+      },
+      mergeData(oldData: any, data: any) {
+        return mergeData(oldData, data);
+      },
+    };
+
+    const updaterB: DataUpdater = {
+      name: "Updater B",
+      defaults: {},
+      async fetchData() {
+        return { [sharedFile]: { b: "new-b" } };
+      },
+      mergeData(oldData: any, data: any) {
+        return mergeData(oldData, data);
+      },
+    };
+
+    const manager = new DataManager();
+    manager.registerUpdater(updaterA);
+    manager.registerUpdater(updaterB);
+
+    await manager.updateAll();
+
+    const updated = JSON.parse(await readFile(sharedFile, "utf8"));
+    expect(updated).toEqual({ a: "new-a", b: "new-b" });
+  });
+});

--- a/src/data-manager.ts
+++ b/src/data-manager.ts
@@ -69,7 +69,8 @@ export class DataManager {
    */
   async updateFromSource(
     updaterName: string,
-    options: UpdateOptions = {}
+    options: UpdateOptions = {},
+    existingByFile?: Map<string, any>
   ): Promise<{
     success: boolean;
     results?: { [file: string]: UpdateResult<any> };
@@ -88,8 +89,6 @@ export class DataManager {
       const filePaths = this.getFilePathsForData(fileDataMap);
 
       const results: { [file: string]: UpdateResult<any> } = {};
-      let totalAdded = 0;
-      let totalUpdated = 0;
 
       // Process each file
       for (const [fileKey, incomingData] of Object.entries(fileDataMap)) {
@@ -101,9 +100,13 @@ export class DataManager {
           : incomingData;
 
         let existing: any = {};
-        try {
-          existing = await loadExisting(targetFile);
-        } catch {}
+        if (existingByFile?.has(targetFile)) {
+          existing = existingByFile.get(targetFile);
+        } else {
+          try {
+            existing = await loadExisting(targetFile);
+          } catch {}
+        }
 
         // Use the updater's defaults
         const defaults = updater.defaults || {};
@@ -122,13 +125,8 @@ export class DataManager {
           data: result,
           targetFile,
         };
-
-        totalAdded += result.added;
-        totalUpdated += result.updated;
-
-        console.log(
-          `  ${fileKey}: +${result.added} added, ${result.updated} updated -> ${targetFile}`
-        );
+        existingByFile?.set(targetFile, result);
+        console.log(`  ${fileKey} -> ${targetFile}`);
       }
 
       return {
@@ -148,19 +146,22 @@ export class DataManager {
    */
   async updateAll(options: UpdateOptions = {}): Promise<void> {
     const allResults: MultiFileUpdateResult[] = [];
+    const existingByFile = new Map<string, any>();
 
     for (const updater of this.updaters) {
       console.log(`Processing ${updater.name}...`);
 
       try {
-        const updateResult = await this.updateFromSource(updater.name, options);
+        const updateResult = await this.updateFromSource(
+          updater.name,
+          options,
+          existingByFile
+        );
 
         if (updateResult.success && updateResult.results) {
           allResults.push(updateResult.results as any);
           console.log(
-            `${updateResult.results} updated across ${
-              Object.keys(updateResult.results).length
-            } files`
+            `${Object.keys(updateResult.results).length} files prepared`
           );
         } else {
           console.error(
@@ -268,14 +269,16 @@ export class DataManager {
     allResults: MultiFileUpdateResult[]
   ): Promise<void> {
     const writtenFiles: string[] = [];
-    const allFileResults: UpdateResult<any>[] = [];
+    const latestResultByPath = new Map<string, UpdateResult<any>>();
 
-    // Flatten all results
+    // Keep only the latest computed result per target file.
     for (const multiResult of allResults) {
       for (const result of Object.values(multiResult)) {
-        allFileResults.push(result);
+        latestResultByPath.set(result.targetFile, result);
       }
     }
+
+    const allFileResults = Array.from(latestResultByPath.values());
 
     // Write each result to its target file
     for (const result of allFileResults) {


### PR DESCRIPTION
## summary
- fix a data integrity bug where later updaters could overwrite earlier changes when both write the same file in one run
- keep an in-memory per-file state during updateAll and only write the latest computed payload per file
- add a regression test that reproduces and prevents the rollback case
- made by mooncitydev

## test plan
- [x] add regression test for two updaters writing one file
- [x] run 
pm test (blocked locally by postinstall/windows env issue in this workspace)
